### PR TITLE
Opening level time zone conversion

### DIFF
--- a/src/components/venue-directory/VenueDirectory.jsx
+++ b/src/components/venue-directory/VenueDirectory.jsx
@@ -103,7 +103,7 @@ export function VenueDirectory(props) {
     scheduledVenuesRender.push(
       <div className="aether-venues__day" key={i}>
         <details open>
-          <summary><h2>{currentDay === i ? "Today" : currentDay === i - 1 ? "Tomorrow" : days[i]}</h2></summary>
+          <summary><h2>{currentDay === i ? `Today (${days[i]})` : currentDay === i - 1 ? `Tomorrow (${days[i]})` : days[i]}</h2></summary>
           { listView 
             ? <VenueList venues={filteredScheduled} />
             : <VenueStrip venues={filteredScheduled} /> }

--- a/src/model/Opening.js
+++ b/src/model/Opening.js
@@ -5,7 +5,6 @@ class Opening {
     constructor(props) {
         Object.assign(this, props);
         this.ranking = this._getRanking();
-        // todo: Data currently contains timeZone ID's that are not IANA, so use UTC
         this.local = timeService.convertToLocalOpening(this);
     }
 

--- a/src/services/timeService.js
+++ b/src/services/timeService.js
@@ -6,7 +6,7 @@ class TimeService {
     }
 
     getLocalDay() {
-        const day = new Date().getUTCDay() - 1;
+        const day = new Date().getDay() - 1;
         return day < 0 ? day + 7 : day;
     }
 


### PR DESCRIPTION
Clarifiying the day that "Today" and "Tomorrow" is referring to, this will help most when "Today" flips after midnight, saving from any ambiguity. 